### PR TITLE
Sort compound_finder SVs prior to processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.14.5
+* Reproducibility fix: ensure `compound_finder.pl` iterates over SVs in the same order between runs.
+
 ### 3.14.4
 * Routine update of bed intersect file
 

--- a/bin/compound_finder.pl
+++ b/bin/compound_finder.pl
@@ -80,7 +80,7 @@ while ( my $b = $vcf2->next_var() ) {
 	## if gene-match check compounding
 	## else check overlap
 	## else not confounding
-	foreach my $SVvar (keys %{$svc}) {
+	foreach my $SVvar (sort keys %{$svc}) {
 		my $svPOS = $svc->{$SVvar}->{POS};
 		my $svEND = $svc->{$SVvar}->{END};
 		my $svlen = $svc->{$SVvar}->{SVLEN};


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Currently `compound_finder.pl` reads all SVs into a perl hash and later iterates over the keys as-is when resolving compounds. As perl hashes are unordered by default this might lead to confusing diffs when comparing two runs side-by-side.

This fix applies a simple sort to the keys in the hash. 


## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Patch
- [ ] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
