### PR TITLE
Gens v4 const suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.20.1
+* Update Gens CRON suffix `.gens_v4` -> `.gens_v4_const`
+
 ### 3.20.0
 * Gens v4 label updates
 * Don't CRON load Gens v4 UPD track for singles and parent samples

--- a/main.nf
+++ b/main.nf
@@ -2895,7 +2895,7 @@ process generate_gens_v4_meta {
 }
 
 process gens_v4_cron {
-	publishDir "${params.crondir}/gens", mode: 'copy', overwrite: 'true', pattern: "*.gens_v4"
+	publishDir "${params.crondir}/gens", mode: 'copy', overwrite: 'true', pattern: "*.gens_v4_const"
 	tag "$id"
 	cpus 1
 	time '10m'
@@ -2905,7 +2905,7 @@ process gens_v4_cron {
 		tuple val(group), val(id), val(type), val(sex), path(track_roh), path(track_upd), path(meta_tsv), path(chrom_meta_tsv)
 	
 	output:
-		path("${id}.gens_v4"), emit: gens_v4_middleman
+		path("${id}.gens_v4_const"), emit: gens_v4_middleman
 	
 	when:
 		params.prepare_gens_data
@@ -2923,7 +2923,7 @@ process gens_v4_cron {
 			--sample-type $type \\
 			--baf ${params.gens_accessdir}/${id}.baf.bed.gz \\
 			--coverage ${params.gens_accessdir}/${id}.cov.bed.gz \\
-			${meta_opts}" > ${id}.gens_v4
+			${meta_opts}" > ${id}.gens_v4_const
 
 		if [[ "$type" == "proband" ]]; then
 			echo "gens load sample-annotation \\
@@ -2931,7 +2931,7 @@ process gens_v4_cron {
 				--case-id $group \\
 				--genome-build 38 \\
 				--file ${params.gens_accessdir}/${track_roh.getName()} \\
-				--name \\\"LOH\\\"" >> ${id}.gens_v4
+				--name \\\"LOH\\\"" >> ${id}.gens_v4_const
 
 			# Only load UPD track for proband with family
 			if [[ "${params.mode}" == "family" ]]; then
@@ -2940,14 +2940,14 @@ process gens_v4_cron {
 					--case-id $group \\
 					--genome-build 38 \\
 					--file ${params.gens_accessdir}/${track_upd.getName()} \\
-					--name \\\"UPS\\\"" >> ${id}.gens_v4
+					--name \\\"UPS\\\"" >> ${id}.gens_v4_const
 			fi
 		fi
 		"""
 	
 	stub:
 		"""
-		touch "${id}.gens_v4"
+		touch "${id}.gens_v4_const"
 		"""
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Suffix of Gens v4 CRON file changed from `gens_v4` to `gens_v4_const` to separate it from somatic CRON jobs.

- [x] Codex review https://github.com/Jakob37/nextflow_wgs/pull/5

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [x] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Documentation
- [ ] At least one other person has reviewed my changes (not required for trivial changes)

## Patch
- [x] Stub run completes without errors or new warnings (run both trio and single here)
- [x] At least one other person has reviewed and approved my code (not required for trivial changes)

## Major / Minor change
- [ ] Stub run completes without errors or new warnings
- [ ] GIAB single (wgs) finishes and differences to current master branch have been investigated (using [PipeEval](https://github.com/Clinical-Genomics-Lund/PipeEval))
- [ ] GIAB trio (wgs) finishes and differences to current master branch have been investigated
- [ ] Seracare (onco) sample finishes and differences to current master branch have been investigated
- [ ] Output from processes with altered code have been inspected (i.e. in the work folder: .command.sh, .command.log, .command.err and result files)
- [ ] All three samples can be loaded into Scout
- [ ] At least one other person has reviewed and approved my code
- [ ] I have made corresponding changes to the documentation (software versions, etc.)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [x] Viktor

(Add if missing)

## Testing performed by

- [ ] Alexander
- [x] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
