### PR TITLE
Fix lsp parsing and move VCF record presence check to own function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 3.20.8
+* Fix LSP parsing error introduced in #353
+* Update `constitutional` vcf record checking code with valid nxf syntax and move to own function
+
 ### 3.20.7
 * Rename all instances of `Channel` to `channel`
 

--- a/main.nf
+++ b/main.nf
@@ -4,6 +4,7 @@ include { SNV_ANNOTATE } from './workflows/annotate_snvs.nf'
 include { IDSNP_CALL } from './modules/idsnp.nf'
 include { IDSNP_VCF_TO_JSON } from './modules/idsnp.nf'
 include { VALIDATE_SAMPLES_CSV } from './workflows/validate_csv.nf'
+include { vcfHasVariants } from './workflows/util.nf'
 
 nextflow.enable.dsl=2
 
@@ -675,16 +676,7 @@ workflow NEXTFLOW_WGS {
 				def has_sv = true // to allow for stub
 
 				if (merged_vcf.exists() && merged_vcf.size() > 0) {
-					has_sv = false
-					merged_vcf.withReader { reader ->
-						String line
-						while ((line = reader.readLine()) != null) {
-							if (!line.startsWith('#')) {
-								has_sv = true
-								break
-							}
-						}
-					}
+					has_sv = vcfHasVariants(merged_vcf)
 				}
 
 				tuple(group, id, merged_vcf, has_sv)

--- a/workflows/util.nf
+++ b/workflows/util.nf
@@ -1,0 +1,27 @@
+nextflow.enable.dsl = 2
+
+
+/*
+ * Returns true if VCF contains at least one non-header, non-blank line 
+ * Returns false if VCF does not exist OR contains NO non-header records 
+ */
+def vcfHasVariants(Path vcf) {
+    
+    if (vcf.size() < 1) {
+        return false
+    }
+
+    def found = false
+
+    vcf.withReader { reader ->
+        reader.eachLine { line ->
+            def s = line.trim()
+            if (s && !s.startsWith('#')) {
+                found = true
+                return
+            }
+        }
+    }
+
+    return found
+}

--- a/workflows/util.nf
+++ b/workflows/util.nf
@@ -13,7 +13,13 @@ def vcfHasVariants(Path vcf) {
 
     def found = false
 
-    vcf.withReader { reader ->
+    // Detect  gzipped files
+    def inputStream = java.nio.file.Files.newInputStream(vcf)
+    if (vcf.name.endsWith('.gz')) {
+        inputStream = new java.util.zip.GZIPInputStream(inputStream)
+    }
+
+    inputStream.withReader { reader ->
         reader.eachLine { line ->
             def s = line.trim()
             if (s && !s.startsWith('#')) {


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

This update fixes the bug introduced in #353  that breaks nxf language server parsing with a var assignment inside a while condition. 

The code that checks for presence of variant records in VCFs has been updated with valid NXF syntax and moved to a function inside new workflow `./workflows/util.nf`

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [ ] Patch
- [x] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Major / Minor change
- [x] Stub run completes without errors or new warnings
- [x] Constitutional sample finishes and behaves as expected for VCFs with SVs no SVs
- [x] Output from processes with altered code have been inspected (i.e. in the work folder: .command.sh, .command.log, .command.err and result files)
- [ ] At least one other person has reviewed and approved my code
- [ ] I have made corresponding changes to the documentation (software versions, etc.)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
