### PR TITLE
Vh/idsnps peddy2cdm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 3.24.1
+* Added peddy sex-check and ped-check as a CDM output
+* changed json for ID-SNPs to be in the same format as somatic unpaired samples
+
 ### 3.24.0
 * Update vep to 114.2
 * Update bed intersect with ensembl/114 and clinvar/20260226 

--- a/bin/genotype_to_json.py
+++ b/bin/genotype_to_json.py
@@ -13,9 +13,13 @@ def main():
     args = parser.parse_args()
 
     genotype_data = parse_genotype_file(args.genotype_file)
+    idsnp_json_format = {
+        "is_paired_sample" : False,
+        "id_snp_genotypes" : genotype_data
+    }
     
     with open(args.output_file, 'w') as output_file:
-        json.dump(genotype_data, output_file, indent=4)
+        json.dump(idsnp_json_format, output_file, indent=4)
     
     
 def parse_genotype_file(genotype_file_path: str) -> Dict[str, str]:

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import csv
 import json
+import argparse
 from datetime import datetime, timezone
 
 def load_sex_check(file_path, sample):
@@ -69,7 +70,7 @@ def build_per_sample_outputs(sex_ok, ped_sex, ped_rows, sample, samples_dict):
         "is_correct_sex": sex_ok,
         "pedigree_sex" : ped_sex,
     }
-    
+
     result["sex_check"] = sex_check
 
     if is_trio:
@@ -140,8 +141,7 @@ def main(ped_file, sex_file, sample_arg, cdmassay,results_dir):
 
 
 if __name__ == "__main__":
-    import argparse
-
+    
     parser = argparse.ArgumentParser(description="Process PED and SEX check files")
     parser.add_argument("--ped", required=True, help="id.ped_check.csv")
     parser.add_argument("--sex", required=True, help="id.sex_check.csv")

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import csv
+import json
+
+def load_sex_check(file_path):
+    sex_data = {}
+
+    with open(file_path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            sample_id = row["sample_id"]
+            sex_ok = row["error"].lower() == "false"
+            sex_data[sample_id] = sex_ok
+
+    return sex_data
+
+
+def load_ped_check(file_path):
+    ped_rows = []
+    with open(file_path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ped_rows.append(row)
+    return ped_rows
+
+
+def evaluate_kinship(ped_rows, proband, father, mother):
+    """
+    return mother father errors
+    """
+    rel_status = {}
+
+    for row in ped_rows:
+        if row['sample_a'] == proband and row['sample_b'] == mother:
+            rel_status['mother'] = is_correct(row)
+            rel_status['mother_id'] = mother
+        if row['sample_a'] == proband and row['sample_b'] == father:
+            rel_status['father'] = is_correct(row)
+            rel_status['father_id'] = father
+
+    return rel_status
+
+def is_correct(row):
+    parent_error = row["parent_error"].lower() == "true"
+    is_correct = not parent_error
+    return is_correct
+    
+
+def build_per_sample_outputs(sex_data, ped_rows, proband, father, mother):
+    is_trio = len(ped_rows) > 0
+
+    results = {}
+
+    if is_trio:
+        rel_status = evaluate_kinship(ped_rows, proband, father, mother)
+
+    for sample_id, sex_ok in sex_data.items():
+        result = {
+            "trio": is_trio,
+            "sex": sex_ok
+        }
+
+        if is_trio:
+            if sample_id == proband:
+                result["kinship"] = rel_status
+            elif sample_id in (father, mother):
+                role = "father" if sample_id == father else "mother"
+                result["kinship"] = {"proband": rel_status.get(role, False), "proband_id" : proband}
+
+        results[sample_id] = result
+
+    return results
+
+
+def write_individual_jsons(results):
+
+    for sample_id, data in results.items():
+        filename = f"{sample_id}.json"
+        with open(filename, "w") as f:
+            json.dump(data, f, indent=2)
+
+
+def main(ped_file, sex_file, proband, father, mother):
+    sex_data = load_sex_check(sex_file)
+    ped_rows = load_ped_check(ped_file)
+
+    results = build_per_sample_outputs(sex_data, ped_rows, proband, father, mother)
+
+    write_individual_jsons(results)
+
+    print(f"Wrote {len(results)} JSON files")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process PED and SEX check files")
+    parser.add_argument("--ped", required=True, help="id.ped_check.csv")
+    parser.add_argument("--sex", required=True, help="id.sex_check.csv")
+    parser.add_argument("--proband", required=True, help="proband-id")
+    parser.add_argument("--mother", default=None, help="mother-id")
+    parser.add_argument("--father", default=None, help="father-id")
+
+    args = parser.parse_args()
+
+    main(args.ped, args.sex, args.proband, args.father, args.mother)

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -4,10 +4,11 @@ import json
 import argparse
 from datetime import datetime, timezone
 
+
 def load_sex_check(file_path, sample):
     sex_ok = True
     found = False
-    with open(file_path, newline='') as f:
+    with open(file_path, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
             sample_id = row["sample_id"]
@@ -22,7 +23,7 @@ def load_sex_check(file_path, sample):
 
 def load_ped_check(file_path):
     ped_rows = []
-    with open(file_path, newline='') as f:
+    with open(file_path, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
             ped_rows.append(row)
@@ -36,27 +37,28 @@ def evaluate_kinship(ped_rows, sample_id, samples_dict):
     rel_status = {}
 
     for row in ped_rows:
-        if row['sample_a'] == sample_id:
-            other = row['sample_b']
+        if row["sample_a"] == sample_id:
+            other = row["sample_b"]
             rel_status[other] = {
                 "is_correct": is_correct(row),
-                "sequencing_run": samples_dict.get(other)
+                "sequencing_run": samples_dict.get(other),
             }
 
-        if row['sample_b'] == sample_id:
-            other = row['sample_a']
+        if row["sample_b"] == sample_id:
+            other = row["sample_a"]
             rel_status[other] = {
                 "is_correct": is_correct(row),
-                "sequencing_run": samples_dict.get(other)
+                "sequencing_run": samples_dict.get(other),
             }
 
     return rel_status
+
 
 def is_correct(row):
     parent_error = row["parent_error"].lower() == "true"
     is_correct = not parent_error
     return is_correct
-    
+
 
 def build_per_sample_outputs(sex_ok, ped_sex, ped_rows, sample, samples_dict):
     is_trio = len(ped_rows) > 0
@@ -68,32 +70,35 @@ def build_per_sample_outputs(sex_ok, ped_sex, ped_rows, sample, samples_dict):
 
     sex_check = {
         "is_correct_sex": sex_ok,
-        "pedigree_sex" : ped_sex,
+        "pedigree_sex": ped_sex,
     }
 
     result["sex_check"] = sex_check
 
     if is_trio:
-        result['kinship'] = rel_status
+        result["kinship"] = rel_status
 
-    result['analysis_date'] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    result["analysis_date"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return result
 
 
 def write_individual_jsons(results, output):
 
-
     filename = output
     with open(filename, "w") as f:
         json.dump(results, f, indent=2)
 
-def write_cdm_load(sample,cdmassay,output_file,samples_dict,results_dir):
+
+def write_cdm_load(sample, cdmassay, output_file, samples_dict, results_dir):
 
     seqrun = samples_dict.get(sample)
     filename = f"{sample}.peddy2cdm"
     with open(filename, "w") as f:
-        f.write(f"--sequencing-run {seqrun} --assay {cdmassay} --sample-id {sample} --peddy {results_dir}/{output_file}")
+        f.write(
+            f"--sequencing-run {seqrun} --assay {cdmassay} --sample-id {sample} --peddy {results_dir}/{output_file}"
+        )
+
 
 def parse_samples(sample_arg):
     """
@@ -116,7 +121,8 @@ def parse_samples(sample_arg):
 
     return samples
 
-def main(ped_file, sex_file, sample_arg, cdmassay,results_dir):
+
+def main(ped_file, sex_file, sample_arg, cdmassay, results_dir):
     ped_rows = load_ped_check(ped_file)
 
     samples_dict = parse_samples(sample_arg)
@@ -125,23 +131,17 @@ def main(ped_file, sex_file, sample_arg, cdmassay,results_dir):
         sex_ok, ped_sex = load_sex_check(sex_file, sample)
 
         result = build_per_sample_outputs(
-            sex_ok,
-            ped_sex,
-            ped_rows,
-            sample,
-            samples_dict
+            sex_ok, ped_sex, ped_rows, sample, samples_dict
         )
 
-
         output_file = f"{sample}_peddy.json"
-        
+
         write_individual_jsons(result, output_file)
-        write_cdm_load(sample,cdmassay,output_file,samples_dict,results_dir)
-        
+        write_cdm_load(sample, cdmassay, output_file, samples_dict, results_dir)
 
 
 if __name__ == "__main__":
-    
+
     parser = argparse.ArgumentParser(description="Process PED and SEX check files")
     parser.add_argument("--ped", required=True, help="id.ped_check.csv")
     parser.add_argument("--sex", required=True, help="id.sex_check.csv")

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -63,21 +63,21 @@ def build_per_sample_outputs(sex_ok, ped_rows, sample):
     return result
 
 
-def write_individual_jsons(results, sample):
+def write_individual_jsons(results, output):
 
 
-    filename = f"{sample}.json"
+    filename = output
     with open(filename, "w") as f:
         json.dump(results, f, indent=2)
 
 
-def main(ped_file, sex_file, sample):
+def main(ped_file, sex_file, sample, output):
     sex_ok = load_sex_check(sex_file,sample)
     ped_rows = load_ped_check(ped_file)
 
     result = build_per_sample_outputs(sex_ok, ped_rows, sample)
 
-    write_individual_jsons(result, sample)
+    write_individual_jsons(result, output)
 
 
 if __name__ == "__main__":
@@ -87,8 +87,12 @@ if __name__ == "__main__":
     parser.add_argument("--ped", required=True, help="id.ped_check.csv")
     parser.add_argument("--sex", required=True, help="id.sex_check.csv")
     parser.add_argument("--sample", required=True, help="id of sample")
+    parser.add_argument("--output", default=None, help="id of sample")
 
 
     args = parser.parse_args()
 
-    main(args.ped, args.sex, args.sample)
+    if args.output is None:
+        args.output = f"{args.sample}.json"
+
+    main(args.ped, args.sex, args.sample, args.output)

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -111,7 +111,7 @@ def write_cdm_load(sample, cdmassay, output_file, samples_dict, results_dir):
         )
 
 
-def parse_samples(sample_arg):
+def parse_samples(sample_args):
     """
     expects  s1:run_idX for single samples
     and s1:run_idX&s2:run_idX&s3:run_idX for trios
@@ -122,18 +122,16 @@ def parse_samples(sample_arg):
     }
     """
     samples = {}
-    parts = sample_arg.split("&")
 
-    for part in parts:
+    for part in sample_args:
         if ":" in part:
             sample, seqrun = part.split(":", 1)
         else:
-            exit("Need to provide sequencing_run id s1:run_idX or s1:run_idX&s2:run_idX&s3:run_idX for trios")
+            exit("Need format s1:run_idX")
 
         samples[sample] = seqrun
 
     return samples
-
 
 def main(ped_file, sex_file, sample_arg, cdmassay, results_dir):
     ped_rows = load_ped_check(ped_file)
@@ -158,7 +156,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process PED and SEX check files")
     parser.add_argument("--ped", required=True, help="id.ped_check.csv")
     parser.add_argument("--sex", required=True, help="id.sex_check.csv")
-    parser.add_argument("--sample", required=True, help="id of sample")
+    parser.add_argument("--sample", required=True, action="append", help="sample:run_id (can be used multiple times)")
     parser.add_argument("--cdmassay", required=True, help="cdm assay of sample")
     parser.add_argument("--results_dir", required=True, help="cdm assay of sample")
 

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -93,7 +93,7 @@ def write_cdm_load(sample,cdmassay,output_file,samples_dict,results_dir):
     seqrun = samples_dict.get(sample)
     filename = f"{sample}.peddy2cdm"
     with open(filename, "w") as f:
-        f.write(f"--sequencing_run {seqrun} --assay {cdmassay} --sample-id {sample} --peddy {results_dir}/{output_file}")
+        f.write(f"--sequencing-run {seqrun} --assay {cdmassay} --sample-id {sample} --peddy {results_dir}/{output_file}")
 
 def parse_samples(sample_arg):
     """

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -2,17 +2,19 @@
 import csv
 import json
 
-def load_sex_check(file_path):
-    sex_data = {}
-
+def load_sex_check(file_path, sample):
+    sex_ok = True
+    found = False
     with open(file_path, newline='') as f:
         reader = csv.DictReader(f)
         for row in reader:
             sample_id = row["sample_id"]
-            sex_ok = row["error"].lower() == "false"
-            sex_data[sample_id] = sex_ok
-
-    return sex_data
+            if sample_id == sample:
+                found = True
+                sex_ok = row["error"].lower() == "false"
+    if not found:
+        exit(f"{sample} is not in pedigree")
+    return sex_ok
 
 
 def load_ped_check(file_path):
@@ -24,19 +26,17 @@ def load_ped_check(file_path):
     return ped_rows
 
 
-def evaluate_kinship(ped_rows, proband, father, mother):
+def evaluate_kinship(ped_rows, sample_id):
     """
-    return mother father errors
+    returns all matchings to other samples in trio
     """
     rel_status = {}
 
     for row in ped_rows:
-        if row['sample_a'] == proband and row['sample_b'] == mother:
-            rel_status['mother'] = is_correct(row)
-            rel_status['mother_id'] = mother
-        if row['sample_a'] == proband and row['sample_b'] == father:
-            rel_status['father'] = is_correct(row)
-            rel_status['father_id'] = father
+        if row['sample_a'] == sample_id:
+            rel_status[row['sample_b']] = is_correct(row)
+        if row['sample_b'] == sample_id:
+            rel_status[row['sample_a']] = is_correct(row)
 
     return rel_status
 
@@ -46,49 +46,38 @@ def is_correct(row):
     return is_correct
     
 
-def build_per_sample_outputs(sex_data, ped_rows, proband, father, mother):
+def build_per_sample_outputs(sex_ok, ped_rows, sample):
     is_trio = len(ped_rows) > 0
 
-    results = {}
+    if is_trio:
+        rel_status = evaluate_kinship(ped_rows, sample)
+
+    result = {
+        "trio": is_trio,
+        "sex": sex_ok
+    }
 
     if is_trio:
-        rel_status = evaluate_kinship(ped_rows, proband, father, mother)
+        result['kinship'] = rel_status
 
-    for sample_id, sex_ok in sex_data.items():
-        result = {
-            "trio": is_trio,
-            "sex": sex_ok
-        }
-
-        if is_trio:
-            if sample_id == proband:
-                result["kinship"] = rel_status
-            elif sample_id in (father, mother):
-                role = "father" if sample_id == father else "mother"
-                result["kinship"] = {"proband": rel_status.get(role, False), "proband_id" : proband}
-
-        results[sample_id] = result
-
-    return results
+    return result
 
 
-def write_individual_jsons(results):
-
-    for sample_id, data in results.items():
-        filename = f"{sample_id}.json"
-        with open(filename, "w") as f:
-            json.dump(data, f, indent=2)
+def write_individual_jsons(results, sample):
 
 
-def main(ped_file, sex_file, proband, father, mother):
-    sex_data = load_sex_check(sex_file)
+    filename = f"{sample}.json"
+    with open(filename, "w") as f:
+        json.dump(results, f, indent=2)
+
+
+def main(ped_file, sex_file, sample):
+    sex_ok = load_sex_check(sex_file,sample)
     ped_rows = load_ped_check(ped_file)
 
-    results = build_per_sample_outputs(sex_data, ped_rows, proband, father, mother)
+    result = build_per_sample_outputs(sex_ok, ped_rows, sample)
 
-    write_individual_jsons(results)
-
-    print(f"Wrote {len(results)} JSON files")
+    write_individual_jsons(result, sample)
 
 
 if __name__ == "__main__":
@@ -97,10 +86,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process PED and SEX check files")
     parser.add_argument("--ped", required=True, help="id.ped_check.csv")
     parser.add_argument("--sex", required=True, help="id.sex_check.csv")
-    parser.add_argument("--proband", required=True, help="proband-id")
-    parser.add_argument("--mother", default=None, help="mother-id")
-    parser.add_argument("--father", default=None, help="father-id")
+    parser.add_argument("--sample", required=True, help="id of sample")
+
 
     args = parser.parse_args()
 
-    main(args.ped, args.sex, args.proband, args.father, args.mother)
+    main(args.ped, args.sex, args.sample)

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -27,7 +27,7 @@ def load_ped_check(file_path):
     return ped_rows
 
 
-def evaluate_kinship(ped_rows, sample_id):
+def evaluate_kinship(ped_rows, sample_id, samples_dict):
     """
     returns all matchings to other samples in trio
     """
@@ -35,9 +35,18 @@ def evaluate_kinship(ped_rows, sample_id):
 
     for row in ped_rows:
         if row['sample_a'] == sample_id:
-            rel_status[row['sample_b']] = is_correct(row)
+            other = row['sample_b']
+            rel_status[other] = {
+                "is_correct": is_correct(row),
+                "sequencing_run": samples_dict.get(other)
+            }
+
         if row['sample_b'] == sample_id:
-            rel_status[row['sample_a']] = is_correct(row)
+            other = row['sample_a']
+            rel_status[other] = {
+                "is_correct": is_correct(row),
+                "sequencing_run": samples_dict.get(other)
+            }
 
     return rel_status
 
@@ -47,16 +56,16 @@ def is_correct(row):
     return is_correct
     
 
-def build_per_sample_outputs(sex_ok, ped_rows, sample):
+def build_per_sample_outputs(sex_ok, ped_rows, sample, samples_dict):
     is_trio = len(ped_rows) > 0
 
     if is_trio:
-        rel_status = evaluate_kinship(ped_rows, sample)
+        rel_status = evaluate_kinship(ped_rows, sample, samples_dict)
 
     result = {
         "trio": is_trio,
         "sex": sex_ok,
-        'analysis_date' : datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        'analysis_date': datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
     if is_trio:
@@ -72,14 +81,55 @@ def write_individual_jsons(results, output):
     with open(filename, "w") as f:
         json.dump(results, f, indent=2)
 
+def write_cdm_load(sample,cdmassay,output_file,samples_dict,results_dir):
 
-def main(ped_file, sex_file, sample, output):
-    sex_ok = load_sex_check(sex_file,sample)
+    seqrun = samples_dict.get(sample)
+    filename = f"{sample}.peddy2cdm"
+    with open(filename, "w") as f:
+        f.write(f"--sequencing_run {seqrun} --assay {cdmassay} --sample-id {sample} --peddy {results_dir}/{output_file}")
+
+def parse_samples(sample_arg):
+    """
+    Returns:
+    {
+        "sample1": "seq1",
+        "sample2": "seq2"
+    }
+    """
+    samples = {}
+    parts = sample_arg.split("-")
+
+    for part in parts:
+        if ":" in part:
+            sample, seqrun = part.split(":", 1)
+        else:
+            sample, seqrun = part, None
+
+        samples[sample] = seqrun
+
+    return samples
+
+def main(ped_file, sex_file, sample_arg, cdmassay,results_dir):
     ped_rows = load_ped_check(ped_file)
 
-    result = build_per_sample_outputs(sex_ok, ped_rows, sample)
+    samples_dict = parse_samples(sample_arg)
 
-    write_individual_jsons(result, output)
+    for sample in samples_dict:
+        sex_ok = load_sex_check(sex_file, sample)
+
+        result = build_per_sample_outputs(
+            sex_ok,
+            ped_rows,
+            sample,
+            samples_dict
+        )
+
+
+        output_file = f"{sample}.json"
+        
+        write_individual_jsons(result, output_file)
+        write_cdm_load(sample,cdmassay,output_file,samples_dict,results_dir)
+        
 
 
 if __name__ == "__main__":
@@ -89,12 +139,9 @@ if __name__ == "__main__":
     parser.add_argument("--ped", required=True, help="id.ped_check.csv")
     parser.add_argument("--sex", required=True, help="id.sex_check.csv")
     parser.add_argument("--sample", required=True, help="id of sample")
-    parser.add_argument("--output", default=None, help="id of sample")
-
+    parser.add_argument("--cdmassay", required=True, help="cdm assay of sample")
+    parser.add_argument("--results_dir", required=True, help="cdm assay of sample")
 
     args = parser.parse_args()
 
-    if args.output is None:
-        args.output = f"{args.sample}.json"
-
-    main(args.ped, args.sex, args.sample, args.output)
+    main(args.ped, args.sex, args.sample, args.cdmassay, args.results_dir)

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import csv
 import json
+from datetime import datetime, timezone
 
 def load_sex_check(file_path, sample):
     sex_ok = True
@@ -54,7 +55,8 @@ def build_per_sample_outputs(sex_ok, ped_rows, sample):
 
     result = {
         "trio": is_trio,
-        "sex": sex_ok
+        "sex": sex_ok,
+        'analysis_date' : datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
     if is_trio:

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 This script takes output files from peddy and creates json input for register_sample.py --peddy
 Needs sex_check.csv and ped_check.csv and sample ids + sequencing run ids
 
-peddy2cdm.py --sex sex_check.csv --ped ped_check.csv --sample s1:run_idX
+peddy2cdm.py --sex sex_check.csv --ped ped_check.csv --sample s1:run_idX (--sample s2:run_idX --sample s3:run_idX ) --cdmassay
 
 In addition the script also creates singaling files for middleman to load json into CDM
 """
@@ -113,8 +113,7 @@ def write_cdm_load(sample, cdmassay, output_file, samples_dict, results_dir):
 
 def parse_samples(sample_args):
     """
-    expects  s1:run_idX for single samples
-    and s1:run_idX&s2:run_idX&s3:run_idX for trios
+    provides a list of sample:run_id
     Returns:
     {
         "sample1": "seq1",

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -13,9 +13,10 @@ def load_sex_check(file_path, sample):
             if sample_id == sample:
                 found = True
                 sex_ok = row["error"].lower() == "false"
+                ped_sex = row["ped_sex"]
     if not found:
         exit(f"{sample} is not in pedigree")
-    return sex_ok
+    return sex_ok, ped_sex
 
 
 def load_ped_check(file_path):
@@ -56,20 +57,25 @@ def is_correct(row):
     return is_correct
     
 
-def build_per_sample_outputs(sex_ok, ped_rows, sample, samples_dict):
+def build_per_sample_outputs(sex_ok, ped_sex, ped_rows, sample, samples_dict):
     is_trio = len(ped_rows) > 0
 
     if is_trio:
         rel_status = evaluate_kinship(ped_rows, sample, samples_dict)
 
-    result = {
-        "trio": is_trio,
-        "sex": sex_ok,
-        'analysis_date': datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    result = {}
+
+    sex_check = {
+        "is_correct_sex": sex_ok,
+        "pedigree_sex" : ped_sex,
     }
+    
+    result["sex_check"] = sex_check
 
     if is_trio:
         result['kinship'] = rel_status
+
+    result['analysis_date'] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return result
 
@@ -115,10 +121,11 @@ def main(ped_file, sex_file, sample_arg, cdmassay,results_dir):
     samples_dict = parse_samples(sample_arg)
 
     for sample in samples_dict:
-        sex_ok = load_sex_check(sex_file, sample)
+        sex_ok, ped_sex = load_sex_check(sex_file, sample)
 
         result = build_per_sample_outputs(
             sex_ok,
+            ped_sex,
             ped_rows,
             sample,
             samples_dict

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -125,7 +125,7 @@ def main(ped_file, sex_file, sample_arg, cdmassay,results_dir):
         )
 
 
-        output_file = f"{sample}.json"
+        output_file = f"{sample}_peddy.json"
         
         write_individual_jsons(result, output_file)
         write_cdm_load(sample,cdmassay,output_file,samples_dict,results_dir)

--- a/bin/peddy2cdm.py
+++ b/bin/peddy2cdm.py
@@ -4,8 +4,20 @@ import json
 import argparse
 from datetime import datetime, timezone
 
+"""
+This script takes output files from peddy and creates json input for register_sample.py --peddy
+Needs sex_check.csv and ped_check.csv and sample ids + sequencing run ids
+
+peddy2cdm.py --sex sex_check.csv --ped ped_check.csv --sample s1:run_idX
+
+In addition the script also creates singaling files for middleman to load json into CDM
+"""
 
 def load_sex_check(file_path, sample):
+    """
+    read sex_check csv from peddy
+    return given sex and if correct
+    """
     sex_ok = True
     found = False
     with open(file_path, newline="") as f:
@@ -40,33 +52,36 @@ def evaluate_kinship(ped_rows, sample_id, samples_dict):
         if row["sample_a"] == sample_id:
             other = row["sample_b"]
             rel_status[other] = {
-                "is_correct": is_correct(row),
+                "is_correct": relation_is_correct(row),
                 "sequencing_run": samples_dict.get(other),
             }
 
         if row["sample_b"] == sample_id:
             other = row["sample_a"]
             rel_status[other] = {
-                "is_correct": is_correct(row),
+                "is_correct": relation_is_correct(row),
                 "sequencing_run": samples_dict.get(other),
             }
 
     return rel_status
 
 
-def is_correct(row):
+def relation_is_correct(row):
     parent_error = row["parent_error"].lower() == "true"
     is_correct = not parent_error
     return is_correct
 
 
 def build_per_sample_outputs(sex_ok, ped_sex, ped_rows, sample, samples_dict):
-    is_trio = len(ped_rows) > 0
+    """
+    for a given sample, check sex correctness and relationship status for others in family
+    """
+    result = {}
 
+    is_trio = len(ped_rows) > 0
     if is_trio:
         rel_status = evaluate_kinship(ped_rows, sample, samples_dict)
-
-    result = {}
+        result["kinship"] = rel_status
 
     sex_check = {
         "is_correct_sex": sex_ok,
@@ -74,10 +89,6 @@ def build_per_sample_outputs(sex_ok, ped_sex, ped_rows, sample, samples_dict):
     }
 
     result["sex_check"] = sex_check
-
-    if is_trio:
-        result["kinship"] = rel_status
-
     result["analysis_date"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return result
@@ -102,6 +113,8 @@ def write_cdm_load(sample, cdmassay, output_file, samples_dict, results_dir):
 
 def parse_samples(sample_arg):
     """
+    expects  s1:run_idX for single samples
+    and s1:run_idX&s2:run_idX&s3:run_idX for trios
     Returns:
     {
         "sample1": "seq1",
@@ -109,13 +122,13 @@ def parse_samples(sample_arg):
     }
     """
     samples = {}
-    parts = sample_arg.split("-")
+    parts = sample_arg.split("&")
 
     for part in parts:
         if ":" in part:
             sample, seqrun = part.split(":", 1)
         else:
-            sample, seqrun = part, None
+            exit("Need to provide sequencing_run id s1:run_idX or s1:run_idX&s2:run_idX&s3:run_idX for trios")
 
         samples[sample] = seqrun
 

--- a/main.nf
+++ b/main.nf
@@ -495,35 +495,17 @@ workflow NEXTFLOW_WGS {
 		ch_output_info = ch_output_info.mix(peddy.out.peddy_INFO)
 		ch_versions = ch_versions.mix(peddy.out.versions.first())
 
-		ch_grouped = ch_samplesheet
+
+		ch_peddy2cdm_input = ch_samplesheet
+			.filter { row -> row.type == "proband" }
 			.map { row ->
-				tuple(row.group, row)
+				def group = row.group
+				def id = row.id
+				def sequencing_run = row.sequencing_run
+				tuple(group, id, sequencing_run)
 			}
-			.groupTuple()
-
-		ch_trios = ch_grouped.map { group, rows ->
-
-			def proband = rows.find { row -> row.type == "proband" }
-			def mother  = rows.find { row -> row.type == "mother" }
-			def father  = rows.find { row -> row.type == "father" }
-
-			// You can decide how strict you want to be:
-			if (!proband) return null
-
-			tuple(
-				group,
-				proband.id,
-				proband.sex,
-				mother?.id,
-				father?.id,
-				rows.collect { r -> 
-					[id: r.id, sequencing_run: r.sequencing_run]
-				}
-			)
-		}.filter { value -> value != null }
-		ch_trios.println()
-
-		peddy2cdm(peddy.out.peddy_files.join(ch_ped_input))
+			
+		peddy2cdm(peddy.out.peddy_files.join(ch_peddy2cdm_input))
 		
 		if (params.antype == "wgs") {
 			// fastgnomad
@@ -2708,31 +2690,30 @@ process peddy2cdm {
 	memory '20 MB'
 	tag "$group"
 	publishDir "${params.results_output_dir}/qc", mode: 'copy', overwrite: 'true', pattern: '*.json'
-	publishDir "${params.crondir}/peddy", mode: 'copy' , overwrite: 'true', pattern: '*.json'
+	publishDir "${params.crondir}/peddy", mode: 'copy' , overwrite: 'true', pattern: '*.peddy2cdm'
 	container "${params.container_pysam_cmdvcf}"
 	time '20m'
 
 	input:
-		tuple val(group), path(ped_check),path(peddy_ped), path(sex_check), val(id), val(type), val(sex), val(mother), val(father)
+		tuple val(group), path(ped_check),path(peddy_ped), path(sex_check), val(id), val(sequencing_run)
 
 	output:
-		tuple val(group), path("*.json"), emit: json
+		tuple val(group), path("${id}_peddy2cdm.json"), emit: json
 
 	script:
-		def mother_arg = mother ? "--mother ${mother}" : ""
-		def father_arg = father ? "--father ${father}" : ""
 		"""
 		peddy2cdm.py \
 		--ped $ped_check \
 		--sex $sex_check \
-		--proband $id \
-		${mother_arg} \
-		${father_arg}
+		--sample $id \
+		--output ${id}_peddy2cdm.json
+		echo "--sequencing-run ${sequencing_run} --sample-id ${id} --assay $params.cdm_assay --peddy ${params.results_output_dir}/qc/${id}_peddy2cdm.json " > ${id}.peddy2cdm
 		"""
+		
 
 	stub:
 		"""
-		touch "${id}.json"
+		touch "${id}_peddy2cdm.json"
 	    """
 
 }

--- a/main.nf
+++ b/main.nf
@@ -2703,10 +2703,14 @@ process peddy2cdm {
 		tuple val(group), path("*peddy2cdm"), emit: cdm
 
 	script:
-		def sample_arg = id
-			.collectWithIndex { s, i -> "${s}:${sequencing_run[i]}" }
-			.join('-')
+		def ids = id instanceof List ? id : [id]
+		def runs = sequencing_run instanceof List ? sequencing_run : [sequencing_run]
 
+		def sample_arg = [ids, runs]
+			.transpose()
+			.collect { s, r -> "${s}:${r}" }
+			.join('-')
+			
 		"""
 		peddy2cdm.py \
 		--ped $ped_check \

--- a/main.nf
+++ b/main.nf
@@ -497,15 +497,26 @@ workflow NEXTFLOW_WGS {
 
 
 		ch_peddy2cdm_input = ch_samplesheet
-			.filter { row -> row.type == "proband" }
 			.map { row ->
 				def group = row.group
 				def id = row.id
 				def sequencing_run = row.sequencing_run
 				tuple(group, id, sequencing_run)
 			}
-			
-		peddy2cdm(peddy.out.peddy_files.join(ch_peddy2cdm_input))
+
+		samples_by_group = ch_peddy2cdm_input
+			.groupTuple(by: 0)
+
+		joined = peddy.out.peddy_files
+    		.join(samples_by_group)
+
+		expanded = joined.flatMap { group, ped_check, peddy_ped, sex_check, samples ->
+    		samples.collect { s ->
+        		def (_, id, sequencing_run) = s
+        		tuple(group, ped_check, peddy_ped, sex_check, id, sequencing_run )
+    		}
+		}
+		peddy2cdm(expanded)
 		
 		if (params.antype == "wgs") {
 			// fastgnomad

--- a/main.nf
+++ b/main.nf
@@ -2705,7 +2705,7 @@ process peddy2cdm {
 		def sample_arg = [id, sequencing_run]
 			.transpose()
 			.collect { sample_id, run_id -> "${sample_id}:${run_id}" }
-			.join('&')
+			.join('--sample ')
 			
 		"""
 		peddy2cdm.py \

--- a/main.nf
+++ b/main.nf
@@ -499,18 +499,12 @@ workflow NEXTFLOW_WGS {
 		ch_peddy2cdm_input = ch_samplesheet
 			.map { row ->
 				tuple(row.group, row.id, row.sequencing_run)
-			}
+			}.groupTuple()
 
 		// add peddy output to each trio case, make sure it is matched on group
 		// combine does not do this and join will only take first entry
-		ch_peddy2cdm = peddy.out.peddy_files
-			.combine(ch_peddy2cdm_input)
-			.filter { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
-				p_group == s_group
-			}
-			.map { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
-				tuple(p_group, ped_check, peddy_ped, sex_check, id, sequencing_run)
-			}
+		ch_peddy2cdm = peddy.out.peddy_files.join(ch_peddy2cdm_input).view()
+			
 
 		peddy2cdm(ch_peddy2cdm)
 		

--- a/main.nf
+++ b/main.nf
@@ -498,25 +498,19 @@ workflow NEXTFLOW_WGS {
 
 		ch_peddy2cdm_input = ch_samplesheet
 			.map { row ->
-				def group = row.group
-				def id = row.id
-				def sequencing_run = row.sequencing_run
-				tuple(group, id, sequencing_run)
+				tuple(row.group, row.id, row.sequencing_run)
 			}
 
-		samples_by_group = ch_peddy2cdm_input
-			.groupTuple(by: 0)
-
-		joined = peddy.out.peddy_files
-    		.join(samples_by_group)
-
-		expanded = joined.flatMap { group, ped_check, peddy_ped, sex_check, samples ->
-    		samples.collect { s ->
-        		def (_, id, sequencing_run) = s
-        		tuple(group, ped_check, peddy_ped, sex_check, id, sequencing_run )
-    		}
-		}
-		peddy2cdm(expanded)
+		peddy2cdm(
+			peddy.out.peddy_files
+				.combine(ch_peddy2cdm_input)
+				.filter { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
+					p_group == s_group
+				}
+				.map { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
+					tuple(p_group, ped_check, peddy_ped, sex_check, id, sequencing_run)
+				}
+		)
 		
 		if (params.antype == "wgs") {
 			// fastgnomad

--- a/main.nf
+++ b/main.nf
@@ -2690,8 +2690,15 @@ process peddy2cdm {
 		tuple val(group), path("*.json"), emit: json
 
 	script:
+		def mother_arg = mother ? "--mother ${mother}" : ""
+		def father_arg = father ? "--father ${father}" : ""
 		"""
-		peddy2cdm.py --ped $ped_check --sex $sex_check --proband $id --mother $mother --father $father
+		peddy2cdm.py \
+		--ped $ped_check \
+		--sex $sex_check \
+		--proband $id \
+		${mother_arg} \
+		${father_arg}
 		"""
 
 	stub:

--- a/main.nf
+++ b/main.nf
@@ -499,7 +499,7 @@ workflow NEXTFLOW_WGS {
 		ch_peddy2cdm_input = ch_samplesheet
 			.map { row ->
 				tuple(row.group, row.id, row.sequencing_run)
-			}
+			}.view()
 
 		peddy2cdm(
 			peddy.out.peddy_files

--- a/main.nf
+++ b/main.nf
@@ -2699,22 +2699,28 @@ process peddy2cdm {
 		tuple val(group), path(ped_check),path(peddy_ped), path(sex_check), val(id), val(sequencing_run)
 
 	output:
-		tuple val(group), path("${id}_peddy2cdm.json"), emit: json
+		tuple val(group), path("*_peddy2cdm.json"), emit: json
+		tuple val(group), path("*_peddy2cdm"), emit: cdm
 
 	script:
+		def sample_arg = id
+			.collectWithIndex { s, i -> "${s}:${sequencing_run[i]}" }
+			.join('-')
+
 		"""
 		peddy2cdm.py \
 		--ped $ped_check \
 		--sex $sex_check \
-		--sample $id \
-		--output ${id}_peddy2cdm.json
-		echo "--sequencing-run ${sequencing_run} --sample-id ${id} --assay $params.cdm_assay --peddy ${params.results_output_dir}/qc/${id}_peddy2cdm.json " > ${id}.peddy2cdm
+		--sample $sample_arg \
+		--cdmassay $params.cdm_assay \
+		--results_dir ${params.results_output_dir}/qc
 		"""
 		
 
 	stub:
 		"""
-		touch "${id}_peddy2cdm.json"
+		touch "${group}_peddy2cdm.json"
+		touch "${group}.peddy2cdm"
 	    """
 
 }

--- a/main.nf
+++ b/main.nf
@@ -494,6 +494,35 @@ workflow NEXTFLOW_WGS {
 		peddy(ch_peddy_input_vcf.join(ch_ped_base, by: [0,1]))
 		ch_output_info = ch_output_info.mix(peddy.out.peddy_INFO)
 		ch_versions = ch_versions.mix(peddy.out.versions.first())
+
+		ch_grouped = ch_samplesheet
+			.map { row ->
+				tuple(row.group, row)
+			}
+			.groupTuple()
+
+		ch_trios = ch_grouped.map { group, rows ->
+
+			def proband = rows.find { row -> row.type == "proband" }
+			def mother  = rows.find { row -> row.type == "mother" }
+			def father  = rows.find { row -> row.type == "father" }
+
+			// You can decide how strict you want to be:
+			if (!proband) return null
+
+			tuple(
+				group,
+				proband.id,
+				proband.sex,
+				mother?.id,
+				father?.id,
+				rows.collect { r -> 
+					[id: r.id, sequencing_run: r.sequencing_run]
+				}
+			)
+		}.filter { value -> value != null }
+		ch_trios.println()
+
 		peddy2cdm(peddy.out.peddy_files.join(ch_ped_input))
 		
 		if (params.antype == "wgs") {

--- a/main.nf
+++ b/main.nf
@@ -2702,13 +2702,10 @@ process peddy2cdm {
 		tuple val(group), path("*peddy2cdm"), emit: cdm
 
 	script:
-		def ids = id instanceof List ? id : [id]
-		def runs = sequencing_run instanceof List ? sequencing_run : [sequencing_run]
-
-		def sample_arg = [ids, runs]
+		def sample_arg = [id, sequencing_run]
 			.transpose()
-			.collect { s, r -> "${s}:${r}" }
-			.join('-')
+			.collect { sample_id, run_id -> "${sample_id}:${run_id}" }
+			.join('&')
 			
 		"""
 		peddy2cdm.py \

--- a/main.nf
+++ b/main.nf
@@ -2699,8 +2699,8 @@ process peddy2cdm {
 		tuple val(group), path(ped_check),path(peddy_ped), path(sex_check), val(id), val(sequencing_run)
 
 	output:
-		tuple val(group), path("*_peddy2cdm.json"), emit: json
-		tuple val(group), path("*_peddy2cdm"), emit: cdm
+		tuple val(group), path("*peddy.json"), emit: json
+		tuple val(group), path("*peddy2cdm"), emit: cdm
 
 	script:
 		def sample_arg = id
@@ -2719,7 +2719,7 @@ process peddy2cdm {
 
 	stub:
 		"""
-		touch "${group}_peddy2cdm.json"
+		touch "${group}_peddy.json"
 		touch "${group}.peddy2cdm"
 	    """
 

--- a/main.nf
+++ b/main.nf
@@ -503,9 +503,8 @@ workflow NEXTFLOW_WGS {
 
 		// add peddy output to each trio case, make sure it is matched on group
 		// combine does not do this and join will only take first entry
-		ch_peddy2cdm = peddy.out.peddy_files.join(ch_peddy2cdm_input).view()
+		ch_peddy2cdm = peddy.out.peddy_files.join(ch_peddy2cdm_input)
 			
-
 		peddy2cdm(ch_peddy2cdm)
 		
 		if (params.antype == "wgs") {

--- a/main.nf
+++ b/main.nf
@@ -493,10 +493,9 @@ workflow NEXTFLOW_WGS {
 		// TODO: Move this guy to QC:
 		peddy(ch_peddy_input_vcf.join(ch_ped_base, by: [0,1]))
 		ch_output_info = ch_output_info.mix(peddy.out.peddy_INFO)
-
-
 		ch_versions = ch_versions.mix(peddy.out.versions.first())
-
+		peddy2cdm(peddy.out.peddy_files.join(ch_ped_input))
+		
 		if (params.antype == "wgs") {
 			// fastgnomad
 			fastgnomad(
@@ -2639,7 +2638,7 @@ process peddy {
 		tuple val(group), val(type), path(vcf), path(idx), path(ped)
 
 	output:
-		tuple path("${group}.ped_check.csv"),path("${group}.peddy.ped"), path("${group}.sex_check.csv"), emit: peddy_files
+		tuple val(group), path("${group}.ped_check.csv"),path("${group}.peddy.ped"), path("${group}.sex_check.csv"), emit: peddy_files
 		tuple val(group), path("${group}_peddy.INFO"), emit: peddy_INFO
 		path "*versions.yml", emit: versions
 
@@ -2673,6 +2672,33 @@ def peddy_version(task) {
 	    peddy: \$(echo \$(python -m peddy --version 2>&1) | sed 's/^.*peddy, version //')
 	END_VERSIONS
 	"""
+}
+
+process peddy2cdm {
+	cpus 2
+	memory '20 MB'
+	tag "$group"
+	publishDir "${params.results_output_dir}/qc", mode: 'copy', overwrite: 'true', pattern: '*.json'
+	publishDir "${params.crondir}/peddy", mode: 'copy' , overwrite: 'true', pattern: '*.json'
+	container "${params.container_pysam_cmdvcf}"
+	time '20m'
+
+	input:
+		tuple val(group), path(ped_check),path(peddy_ped), path(sex_check), val(id), val(type), val(sex), val(mother), val(father)
+
+	output:
+		tuple val(group), path("*.json"), emit: json
+
+	script:
+		"""
+		peddy2cdm.py --ped $ped_check --sex $sex_check --proband $id --mother $mother --father $father
+		"""
+
+	stub:
+		"""
+		touch "${id}.json"
+	    """
+
 }
 
 // Extract all variants (

--- a/main.nf
+++ b/main.nf
@@ -2705,7 +2705,7 @@ process peddy2cdm {
 		def sample_arg = [id, sequencing_run]
 			.transpose()
 			.collect { sample_id, run_id -> "${sample_id}:${run_id}" }
-			.join('--sample ')
+			.join(' --sample ')
 			
 		"""
 		peddy2cdm.py \

--- a/main.nf
+++ b/main.nf
@@ -499,18 +499,20 @@ workflow NEXTFLOW_WGS {
 		ch_peddy2cdm_input = ch_samplesheet
 			.map { row ->
 				tuple(row.group, row.id, row.sequencing_run)
-			}.view()
+			}
 
-		peddy2cdm(
-			peddy.out.peddy_files
-				.combine(ch_peddy2cdm_input)
-				.filter { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
-					p_group == s_group
-				}
-				.map { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
-					tuple(p_group, ped_check, peddy_ped, sex_check, id, sequencing_run)
-				}
-		)
+		// add peddy output to each trio case, make sure it is matched on group
+		// combine does not do this and join will only take first entry
+		ch_peddy2cdm = peddy.out.peddy_files
+			.combine(ch_peddy2cdm_input)
+			.filter { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
+				p_group == s_group
+			}
+			.map { p_group, ped_check, peddy_ped, sex_check, s_group, id, sequencing_run ->
+				tuple(p_group, ped_check, peddy_ped, sex_check, id, sequencing_run)
+			}
+
+		peddy2cdm(ch_peddy2cdm)
 		
 		if (params.antype == "wgs") {
 			// fastgnomad


### PR DESCRIPTION
# Description and reviewer info

Added a python-script to read peddy output files and create inputs for register_sample.py. This will enable laboratory personnel to
see errors in sex or family setup.

Also changed the ID-SNPs json creation to conform to the same format as in somatic.

## Type of change

- [x] Patch


# Checklist

- [x] Self-review of my code
- [ ] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)


## Patch
- [x] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

# Test/review documentation
Tested onco, single and trio. Files are generated and was able to be loaded into CDM

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
