### PR TITLE
Split reviewer plots across multiple processes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ bin/reference_tools/*.log
 bin/reference_tools/*.bed
 bin/reference_tools/refdata/*.vcf.gz
 
+/.agent-shell/
+.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 3.26.0
 * Split up reviewer loci to one process per locus
+* Add .codex and .agent-shell/ to gitignore 
 
 ### 3.25.2
 * CFTR to constitutional institute...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.26.0
+* Split up reviewer loci to one process per locus
+
 ### 3.25.2
 * CFTR to constitutional institute...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 3.26.0
 * Split up reviewer loci to one process per locus
-* Add .codex and .agent-shell/ to gitignore 
+* Add `.codex` and `.agent-shell/` to gitignore 
 
 ### 3.25.2
 * CFTR to constitutional institute...

--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,7 @@
 #!/usr/bin/env nextflow
 
+import groovy.json.JsonSlurper
+
 include { SNV_ANNOTATE } from './workflows/annotate_snvs.nf'
 include { IDSNP_CALL } from './modules/idsnp.nf'
 include { IDSNP_VCF_TO_JSON } from './modules/idsnp.nf'
@@ -609,15 +611,20 @@ workflow NEXTFLOW_WGS {
 				ch_stranger_meta
 			)
 			ch_output_info = ch_output_info.mix(vcfbreakmulti_expansionhunter.out.str_INFO)
-			ch_reviewer_loci = channel
-				.fromPath(params.expansionhunter_catalog)
-				.splitText()
-				.filter { line -> line.contains('LocusId') }
-				.map { line ->
-					line.replaceAll(/[",^ ]/, '').split(':')[1]
+
+			reviewer_loci = new groovy.json.JsonSlurper()
+				.parseText(file(params.expansionhunter_catalog).text)
+				.collect { locus_definition -> locus_definition.LocusId }
+				.findAll { locus -> locus }
+
+			ch_reviewer_input = expansionhunter.out.bam_vcf
+				.flatMap { group, id, bam, bai, vcf ->
+					reviewer_loci.collect { locus ->
+						tuple(group, id, bam, bai, vcf, locus)
+					}
 				}
 
-			reviewer(expansionhunter.out.bam_vcf.combine(ch_reviewer_loci))
+			reviewer(ch_reviewer_input)
 			ch_output_info = ch_output_info.mix(reviewer.out.reviewer_INFO)
 
 			ch_versions = ch_versions.mix(SMNCopyNumberCaller.out.versions.first())

--- a/main.nf
+++ b/main.nf
@@ -609,7 +609,15 @@ workflow NEXTFLOW_WGS {
 				ch_stranger_meta
 			)
 			ch_output_info = ch_output_info.mix(vcfbreakmulti_expansionhunter.out.str_INFO)
-			reviewer(expansionhunter.out.bam_vcf)
+			ch_reviewer_loci = channel
+				.fromPath(params.expansionhunter_catalog)
+				.splitText()
+				.filter { line -> line.contains('LocusId') }
+				.map { line ->
+					line.replaceAll(/[",^ ]/, '').split(':')[1]
+				}
+
+			reviewer(expansionhunter.out.bam_vcf.combine(ch_reviewer_loci))
 			ch_output_info = ch_output_info.mix(reviewer.out.reviewer_INFO)
 
 			ch_versions = ch_versions.mix(SMNCopyNumberCaller.out.versions.first())
@@ -1712,7 +1720,7 @@ def stranger_version(task) {
 
 
 process reviewer {
-	tag "$group"
+	tag "$group:$locus"
 	cpus 2
 	time '1h'
 	memory '1 GB'
@@ -1721,7 +1729,7 @@ process reviewer {
 	publishDir "${params.results_output_dir}/plots/reviewer/${group}", mode: 'copy' , overwrite: 'true', pattern: '*.svg'
 
 	input:
-		tuple val(group), val(id), path(bam), path(bai), path(vcf)
+		tuple val(group), val(id), path(bam), path(bai), path(vcf), val(locus)
 
 	output:
 		path("*svg")
@@ -1731,17 +1739,13 @@ process reviewer {
 	script:
 		version_str = reviewer_version(task)
 		"""
-		grep LocusId ${params.expansionhunter_catalog} | sed 's/[",^ ]//g' | cut -d':' -f2 > reviewer_loci.txt
-		: > ${group}_reviewer.INFO
-		while read -r locus; do
-			REViewer --reads ${bam} \\
-				--vcf ${vcf} \\
-				--reference ${params.genome_file} \\
-				--catalog ${params.expansionhunter_catalog} \\
-				--locus "\$locus" \\
-				--output-prefix ${id}
-			echo "STR_VARIANTS_IMG	\$locus	${params.accessdir}/plots/reviewer/${group}/${id}.\$locus.svg" >> ${group}_reviewer.INFO
-		done < reviewer_loci.txt
+		REViewer --reads ${bam} \\
+			--vcf ${vcf} \\
+			--reference ${params.genome_file} \\
+			--catalog ${params.expansionhunter_catalog} \\
+			--locus "${locus}" \\
+			--output-prefix ${id}
+		echo "STR_VARIANTS_IMG	${locus}	${params.accessdir}/plots/reviewer/${group}/${id}.${locus}.svg" > ${group}_reviewer.INFO
 
 		echo "${version_str}" > "${task.process}_versions.yml"
 		"""
@@ -1749,8 +1753,8 @@ process reviewer {
 	stub:
 		version_str = reviewer_version(task)
 		"""
-		touch "${id}.svg"
-		touch "${group}_reviewer.INFO"
+		touch "${id}.${locus}.svg"
+		echo "STR_VARIANTS_IMG	${locus}	${params.accessdir}/plots/reviewer/${group}/${id}.${locus}.svg" > "${group}_reviewer.INFO"
 		echo "${version_str}" > "${task.process}_versions.yml"
 		"""
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Reviewer plots are no longer generated in a single process by looping over the Expansionhunter catalog loci, instead the EH catalog is parsed before the process and each loci gets assigned its own process. 

This fixes a recurring issue where a single failed plot generation prevents the generation of remaining plots.

closes #418 

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [ ] Patch
- [x] Minor change
- [ ] Major change 

# Checklist

- [ ] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Documentation
- [ ] At least one other person has reviewed my changes (not required for trivial changes)

## Patch
- [ ] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

## Major / Minor change

- [x] Stub run completes without errors or new warnings
- [ ] GIAB single (wgs) finishes and differences to current master branch have been investigated (using [PipeEval](https://github.com/Clinical-Genomics-Lund/PipeEval))
- [x] GIAB trio (wgs) finishes and differences to current master branch have been investigated
- [ ] Seracare (onco) sample finishes and differences to current master branch have been investigated
- [ ] Output from processes with altered code have been inspected (i.e. in the work folder: .command.sh, .command.log, .command.err and result files)
- [ ] If relevant for your changes - All three samples can be loaded into Scout
- [ ] At least one other person has reviewed and approved my code
- [ ] I have made corresponding changes to the documentation (software versions, etc.)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
