### PR TITLE
Publish STR VCF index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.26.2
+* Emit and publish the ExpansionHunter STR VCF together with its tabix index
+
 ### 3.26.1
 * Set Scout case status to `prioritized` when the proband CSV priority is `highest`
 * Do not load empty SV VCFs into loqusdb

--- a/main.nf
+++ b/main.nf
@@ -1666,7 +1666,6 @@ process expansionhunter {
 	input:
 		tuple val(group), val(id), path(bam), path(bai), val(sex), val(type) // TODO: sex + type are not needed here
 
-
 	output:
 		tuple val(group), val(id), path("${group}.eh.vcf"), emit: expansionhunter_vcf
 		tuple val(group), val(id), path("${group}.eh_realigned.sort.bam"), path("${group}.eh_realigned.sort.bam.bai"), path("${group}.eh.vcf"), emit: bam_vcf
@@ -1798,6 +1797,7 @@ def reviewer_version(task) {
 // FIXME: Use env variable for picard path...
 process vcfbreakmulti_expansionhunter {
 	publishDir "${params.results_output_dir}/vcf", mode: 'copy' , overwrite: 'true', pattern: '*.vcf.gz'
+    publishDir "${params.results_output_dir}/vcf", mode: 'copy' , overwrite: 'true', pattern: '*.vcf.gz.tbi'
 	tag "$group"
 	time '1h'
 	memory '50 GB'
@@ -1807,7 +1807,8 @@ process vcfbreakmulti_expansionhunter {
 		tuple val(group2), val(id2), val(sex), val(mother), val(father), val(phenotype), val(diagnosis), val(type), val(assay), val(clarity_sample_id), val(ffpe), val(analysis)
 
 	output:
-		path("${group}.expansionhunter.vcf.gz"), emit: expansionhunter_scout
+	    tuple val(group), path("${group}.expansionhunter.vcf.gz"), emit: vcf
+        tuple val(group), path("${group}.expansionhunter.vcf.gz.tbi"), emit: tbi
 		tuple val(group), path("${group}_str.INFO"), emit: str_INFO
 		path "*versions.yml", emit: versions
 
@@ -1841,7 +1842,8 @@ process vcfbreakmulti_expansionhunter {
 
 	stub:
 		"""
-		touch "${group}.expansionhunter.vcf.gz"
+	    touch "${group}.expansionhunter.vcf.gz"
+        touch "${group}.expansionhunter.vcf.gz.tbi"
 		touch "${group}_str.INFO"
 
 		${vcfbreakmulti_expansionhunter_version(task)}


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Small change to publish the  tbi of the annotated expansionhunter VCF. 

Scout now requires the STR VCF to be present when loading case 

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [ ] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Documentation
- [ ] At least one other person has reviewed my changes (not required for trivial changes)

## Patch
- [ ] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

## Major / Minor change

- [x] Stub run completes without errors or new warnings
- [x] GIAB single (wgs) finishes and differences to current master branch have been investigated (using [PipeEval](https://github.com/Clinical-Genomics-Lund/PipeEval))
- [ ] GIAB trio (wgs) finishes and differences to current master branch have been investigated
- [ ] Seracare (onco) sample finishes and differences to current master branch have been investigated
- [ ] Output from processes with altered code have been inspected (i.e. in the work folder: .command.sh, .command.log, .command.err and result files)
- [ ] If relevant for your changes - All three samples can be loaded into Scout
- [ ] At least one other person has reviewed and approved my code
- [ ] I have made corresponding changes to the documentation (software versions, etc.)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [x] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
