### PR TITLE
 Define `params.results_output_dir` in nextflow.config instead of inside workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### [Unreleased]
+
+#### Changed
+* Define `params.results_output_dir` in profile config instead of workflow and subworkflow bodies
+
 ### 3.26.3
 * Use boolean values for `publishDir overwrite`
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -204,6 +204,7 @@ profiles {
   wgs {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'wgs'
+    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.loqusdb = "loqusdb_38"
     params.antype = "wgs"
@@ -266,6 +267,7 @@ profiles {
 onco {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'twist-onco'
+    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.cdm_assay = "swea"
     params.gens_accessdir = "/access/twist-onco/plot_data"
@@ -335,6 +337,7 @@ onco {
   oncov1 {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'twist-onco'
+    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.loqusdb = "loqusdb_onco"
     params.antype = "panel"
@@ -405,6 +408,7 @@ onco {
 myeloid {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'myeloid_const'
+    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.gens_accessdir = "/access/myeloid_const/plot_data"
     params.accessdir = "/access/myeloid_const/"
@@ -467,6 +471,7 @@ myeloid {
 constitutional {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'constitutional'
+    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.accessdir = "/access/constitutional/"
     params.gens_accessdir = "/access/constitutional/plot_data"

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -204,7 +204,6 @@ profiles {
   wgs {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'wgs'
-    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.loqusdb = "loqusdb_38"
     params.antype = "wgs"
@@ -267,7 +266,6 @@ profiles {
 onco {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'twist-onco'
-    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.cdm_assay = "swea"
     params.gens_accessdir = "/access/twist-onco/plot_data"
@@ -337,7 +335,6 @@ onco {
   oncov1 {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'twist-onco'
-    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.loqusdb = "loqusdb_onco"
     params.antype = "panel"
@@ -408,7 +405,6 @@ onco {
 myeloid {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'myeloid_const'
-    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.gens_accessdir = "/access/myeloid_const/plot_data"
     params.accessdir = "/access/myeloid_const/"
@@ -471,7 +467,6 @@ myeloid {
 constitutional {
     params.outdir = "${params.resultsdir}${params.dev_suffix}"
     params.subdir = 'constitutional'
-    params.results_output_dir = "${params.outdir}/${params.subdir}"
     params.crondir = "${params.outdir}/cron/"
     params.accessdir = "/access/constitutional/"
     params.gens_accessdir = "/access/constitutional/plot_data"

--- a/main.nf
+++ b/main.nf
@@ -19,11 +19,6 @@ workflow {
 	VALIDATE_PARAMETERS(parameters_to_validate)
 	// Print startup and conf output dirs and modes.
 
-	// TODO: Params assignment inside workflow block is a temp solution:
-	//       outdir and subdir need to be combined in new var, re-setting
-	//       params.outdir won't work.
-	params.results_output_dir = params.outdir + '/' + params.subdir
-
 	// TODO: Pass these to processes in meta?
 	params.mode = file(params.csv).countLines() > 2 ? "family" : "single"
 	params.trio = file(params.csv).countLines() > 3 ? true : false

--- a/main.nf
+++ b/main.nf
@@ -35,7 +35,7 @@ workflow {
 	log.info("Input CSV: " + params.csv)
 	log.info("mode: " + params.mode)
 	log.info("trio analysis: " + params.trio)
-	log.info("Results output dir: " + params.results_output_dir)
+	log.info("Results output dir: ${params.outdir}/${params.subdir}")
 	log.info("Results subdir: " + params.subdir)
 	log.info("CRON output dir: " + params.crondir)
 
@@ -487,7 +487,7 @@ workflow NEXTFLOW_WGS {
 				SMNCopyNumberCaller.out
 					.smn_tsv.collectFile(
 						keepHeader: true,
-						storeDir: "${params.results_output_dir}/smn/")
+						storeDir: "${params.outdir}/${params.subdir}/smn/")
 			)
 
 			// CALL REPEATS //
@@ -995,7 +995,7 @@ process markdup {
 	memory '50 GB' // 12GB peak GIAB
 	time '3h'
 	container  "${params.container_sentieon}"
-	publishDir "${params.results_output_dir}/bam", mode: 'copy' , overwrite: true, pattern: '*_dedup.bam*'
+	publishDir "${params.outdir}/${params.subdir}/bam", mode: 'copy' , overwrite: true, pattern: '*_dedup.bam*'
 
 	input:
 		tuple val(group), val(id), path(bam), path(bai)
@@ -1128,7 +1128,7 @@ process bqsr {
 	// 12gb peak giab //
 	time '5h'
 	container  "${params.container_sentieon}"
-	publishDir "${params.results_output_dir}/bqsr", mode: 'copy' , overwrite: true, pattern: '*.table'
+	publishDir "${params.outdir}/${params.subdir}/bqsr", mode: 'copy' , overwrite: true, pattern: '*.table'
 
 	input:
 		tuple val(group), val(id), path(bam), path(bai)
@@ -1377,7 +1377,7 @@ process sentieon_qc_postprocess {
 process verifybamid2 {
 	cpus 16
 	memory '10 GB'
-	publishDir "${params.results_output_dir}/contamination", mode: 'copy', overwrite: true, pattern: '*.selfSM'
+	publishDir "${params.outdir}/${params.subdir}/contamination", mode: 'copy', overwrite: true, pattern: '*.selfSM'
 	tag "$id"
 	container  "${params.container_verifybamid2}"
 
@@ -1429,7 +1429,7 @@ process depth_onco {
 	cpus 2
 	time '1h'
 	memory '10 GB'
-	publishDir "${params.results_output_dir}/cov", mode: 'copy', overwrite: true
+	publishDir "${params.outdir}/${params.subdir}/cov", mode: 'copy', overwrite: true
 	tag "$id"
 	input:
 		tuple val(group), val(id), path(bam), path(bai)
@@ -1453,7 +1453,7 @@ process SMNCopyNumberCaller {
 	cpus 10
 	memory '25GB'
 	time '2h'
-	publishDir "${params.results_output_dir}/plots/SMNcnc", mode: 'copy' , overwrite: true, pattern: '*.pdf*'
+	publishDir "${params.outdir}/${params.subdir}/plots/SMNcnc", mode: 'copy' , overwrite: true, pattern: '*.pdf*'
 	tag "$id"
 
 	input:
@@ -1621,7 +1621,7 @@ process reviewer {
 	memory '1 GB'
 	errorStrategy 'ignore'
 	container  "${params.container_reviewer}"
-	publishDir "${params.results_output_dir}/plots/reviewer/${group}", mode: 'copy' , overwrite: true, pattern: '*.svg'
+	publishDir "${params.outdir}/${params.subdir}/plots/reviewer/${group}", mode: 'copy' , overwrite: true, pattern: '*.svg'
 
 	input:
 		tuple val(group), val(id), path(bam), path(bai), path(vcf), val(locus)
@@ -1662,8 +1662,8 @@ def reviewer_version(task) {
 // split multiallelic sites in expansionhunter vcf
 // FIXME: Use env variable for picard path...
 process vcfbreakmulti_expansionhunter {
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf.gz'
-    publishDir "${params.results_output_dir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf.gz.tbi'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf.gz'
+    publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf.gz.tbi'
 	tag "$group"
 	time '1h'
 	memory '50 GB'
@@ -1799,7 +1799,7 @@ def gvcf_combine_version(task) {
 process create_ped {
 	tag "${meta.group}"
 	time '20m'
-	publishDir "${params.results_output_dir}/ped", mode: 'copy' , overwrite: true
+	publishDir "${params.outdir}/${params.subdir}/ped", mode: 'copy' , overwrite: true
 	memory '1 GB'
 
 	input:
@@ -1841,7 +1841,7 @@ process create_ped {
 
 //madeline ped, run if family mode
 process madeline {
-	publishDir "${params.results_output_dir}/ped", mode: 'copy' , overwrite: true, pattern: '*.xml'
+	publishDir "${params.outdir}/${params.subdir}/ped", mode: 'copy' , overwrite: true, pattern: '*.xml'
 	memory '1 GB'
 	time '1h'
 	cpus 2
@@ -1982,7 +1982,7 @@ process fetch_MTseqs {
 	memory '10GB'
 	time '1h'
 	tag "$id"
-	publishDir "${params.results_output_dir}/bam", mode: 'copy', overwrite: true, pattern: '*.bam*'
+	publishDir "${params.outdir}/${params.subdir}/bam", mode: 'copy', overwrite: true, pattern: '*.bam*'
 
 	input:
 		tuple val(group), val(id), path(bam), path(bai)
@@ -2103,7 +2103,7 @@ process run_mutect2 {
 	memory '50 GB'
 	time '1h'
 	tag "$group"
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf'
 
 	input:
 		tuple val(group), val(id), path(bam), path(bai)
@@ -2243,7 +2243,7 @@ process run_haplogrep {
 	time '1h'
 	memory '50 GB'
 	cpus 2
-	publishDir "${params.results_output_dir}/plots/mito", mode: 'copy', overwrite: true, pattern: '*.png'
+	publishDir "${params.outdir}/${params.subdir}/plots/mito", mode: 'copy', overwrite: true, pattern: '*.png'
 
 	input:
 		tuple val(group), val(id), path(mito_snv_vcf)
@@ -2300,8 +2300,8 @@ process run_eklipse {
 	// in rare cases with samples above 50 000x this can peak at 500+ GB of VMEM. Add downsampling!
 	memory '100GB'
 	time '60m'
-	publishDir "${params.results_output_dir}/plots/mito", mode: 'copy', overwrite: true, pattern: '*.txt'
-	publishDir "${params.results_output_dir}/plots/mito", mode: 'copy', overwrite: true, pattern: '*.png'
+	publishDir "${params.outdir}/${params.subdir}/plots/mito", mode: 'copy', overwrite: true, pattern: '*.txt'
+	publishDir "${params.outdir}/${params.subdir}/plots/mito", mode: 'copy', overwrite: true, pattern: '*.png'
 
 	input:
 		tuple val(group), val(id), val(meta), path(bam), path(bai)
@@ -2357,7 +2357,7 @@ def run_eklipse_version(task) {
 
 process rename_mito_contigs {
     cpus 2
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf'
 	tag "$group"
 	memory '5 GB'
 	time '1h'
@@ -2404,7 +2404,7 @@ process merge_qc_json {
     cpus 2
     errorStrategy 'retry'
     maxErrors 5
-    publishDir "${params.results_output_dir}/qc", mode: 'copy' , overwrite: true, pattern: '*.QC'
+    publishDir "${params.outdir}/${params.subdir}/qc", mode: 'copy' , overwrite: true, pattern: '*.QC'
     tag "$id"
     time '1h'
 	memory '1 GB'
@@ -2449,15 +2449,15 @@ process qc_to_cdm {
 
 	script:
 		"""
-		echo "--sequencing-run ${meta.sequencing_run} --sample-id ${id} --assay $params.cdm_assay --subassay ${meta.diagnosis} --qc ${params.results_output_dir}/qc/${id}.QC --lims-id ${meta.clarity_sample_id}" > ${id}.cdmpy
+		echo "--sequencing-run ${meta.sequencing_run} --sample-id ${id} --assay $params.cdm_assay --subassay ${meta.diagnosis} --qc ${params.outdir}/${params.subdir}/qc/${id}.QC --lims-id ${meta.clarity_sample_id}" > ${id}.cdmpy
 		"""
 }
 
 
 process peddy {
 
-	publishDir "${params.results_output_dir}/ped", mode: 'copy' , overwrite: true, pattern: '*.ped'
-	publishDir "${params.results_output_dir}/ped", mode: 'copy' , overwrite: true, pattern: '*.csv'
+	publishDir "${params.outdir}/${params.subdir}/ped", mode: 'copy' , overwrite: true, pattern: '*.ped'
+	publishDir "${params.outdir}/${params.subdir}/ped", mode: 'copy' , overwrite: true, pattern: '*.csv'
 
 	cpus 4
 	tag "$group"
@@ -2508,7 +2508,7 @@ process peddy2cdm {
 	cpus 2
 	memory '20 MB'
 	tag "$group"
-	publishDir "${params.results_output_dir}/qc", mode: 'copy', overwrite: true, pattern: '*.json'
+	publishDir "${params.outdir}/${params.subdir}/qc", mode: 'copy', overwrite: true, pattern: '*.json'
 	publishDir "${params.crondir}/peddy", mode: 'copy' , overwrite: true, pattern: '*.peddy2cdm'
 	container "${params.container_pysam_cmdvcf}"
 	time '20m'
@@ -2532,7 +2532,7 @@ process peddy2cdm {
 		--sex $sex_check \
 		--sample $sample_arg \
 		--cdmassay $params.cdm_assay \
-		--results_dir ${params.results_output_dir}/qc
+		--results_dir ${params.outdir}/${params.subdir}/qc
 		"""
 		
 
@@ -2549,7 +2549,7 @@ process fastgnomad {
 	cpus 2
 	memory '40 GB'
 	tag "$group"
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
 	time '2h'
 
 	input:
@@ -2626,7 +2626,7 @@ def upd_version(task) {
 
 
 process upd_table {
-	publishDir "${params.results_output_dir}/plots", mode: 'copy' , overwrite: true
+	publishDir "${params.outdir}/${params.subdir}/plots", mode: 'copy' , overwrite: true
 	tag "$group"
 	time '1h'
 	memory '1 GB'
@@ -2690,7 +2690,7 @@ def roh_version(task) {
 
 // // Create coverage profile using GATK
 process gatkcov {
-	publishDir "${params.results_output_dir}/cov", mode: 'copy' , overwrite: true, pattern: '*.tsv'
+	publishDir "${params.outdir}/${params.subdir}/cov", mode: 'copy' , overwrite: true, pattern: '*.tsv'
 	tag "$group"
 	cpus 2
 	memory '80 GB'
@@ -2755,7 +2755,7 @@ process overview_plot {
 	tag "$group"
 	time '1h'
 	memory '5 GB'
-	publishDir "${params.results_output_dir}/plots", mode: 'copy' , overwrite: true, pattern: "*.png"
+	publishDir "${params.outdir}/${params.subdir}/plots", mode: 'copy' , overwrite: true, pattern: "*.png"
 
 	input:
 		tuple val(group), val(id), val(type), val(sex), path(cov_stand), path(cov_denoised)
@@ -2786,7 +2786,7 @@ process overview_plot {
 }
 
 process generate_gens_data {
-	publishDir "${params.results_output_dir}/plot_data", mode: 'copy' , overwrite: true, pattern: "*.gz*"
+	publishDir "${params.outdir}/${params.subdir}/plot_data", mode: 'copy' , overwrite: true, pattern: "*.gz*"
 	publishDir "${params.crondir}/gens", mode: 'copy', overwrite: true, pattern: "*.gens"
 	tag "$group"
 	cpus 1
@@ -2822,8 +2822,8 @@ process generate_gens_data {
 }
 
 process generate_gens_v4_meta {
-	publishDir "${params.results_output_dir}/plot_data", mode: 'copy', overwrite: true, pattern: "*.tsv"
-	publishDir "${params.results_output_dir}/plot_data", mode: 'copy', overwrite: true, pattern: "*.bed"
+	publishDir "${params.outdir}/${params.subdir}/plot_data", mode: 'copy', overwrite: true, pattern: "*.tsv"
+	publishDir "${params.outdir}/${params.subdir}/plot_data", mode: 'copy', overwrite: true, pattern: "*.bed"
 	tag "$id"
 	cpus 1
 	time '1h'
@@ -3097,7 +3097,7 @@ process postprocessgatk {
 	memory '50GB'
 	time '3h'
 	container  "${params.container_gatk}"
-	publishDir "${params.results_output_dir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
 	tag "$id"
 
 	input:
@@ -3188,7 +3188,7 @@ process filter_merge_gatk {
 	tag "$group"
 	time '2h'
 	memory '1 GB'
-	publishDir "${params.results_output_dir}/sv_vcf", mode: 'copy', overwrite: true
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf", mode: 'copy', overwrite: true
 
 	input:
 		tuple val(group), val(id), path(gentotyped_intervals), path(genotyped_segments), path(denoised_copy_ration)
@@ -3211,7 +3211,7 @@ process filter_merge_gatk {
 
 process manta {
 	cpus  56
-	publishDir "${params.results_output_dir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
 	tag "$id"
 	time '15h'
 	memory '150 GB'
@@ -3251,7 +3251,7 @@ def manta_version(task) {
 
 process manta_panel {
 	cpus  20
-	publishDir "${params.results_output_dir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
 	tag "$id"
 	time '1h'
 	memory '50 GB'
@@ -3296,8 +3296,8 @@ def manta_panel_version(task) {
 process cnvkit_panel {
 	cpus  5
 	container  "${params.container_cnvkit}"
-	publishDir "${params.results_output_dir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf'
-	publishDir "${params.results_output_dir}/plots/", mode: 'copy', overwrite: true, pattern: '*.png'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/plots/", mode: 'copy', overwrite: true, pattern: '*.png'
 	tag "$id"
 	time '1h'
 	memory '20 GB'
@@ -3349,7 +3349,7 @@ def cnvkit_panel_version(task) {
 process cnvkit_scatter {
 	cpus  2
 	container  "${params.container_cnvkit}"
-	publishDir "${params.results_output_dir}/plots/", mode: 'copy', overwrite: true, pattern: '*.png'
+	publishDir "${params.outdir}/${params.subdir}/plots/", mode: 'copy', overwrite: true, pattern: '*.png'
 	tag "$id"
 	time '1h'
 	memory '2 GB'
@@ -3406,7 +3406,7 @@ process svdb_merge_panel {
 	cpus 2
 	cache 'deep'
 	tag "$group"
-	publishDir "${params.results_output_dir}/sv_vcf/merged/", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/merged/", mode: 'copy', overwrite: true, pattern: '*.vcf'
 	time '1h'
 	memory '1 GB'
 	input:
@@ -3492,7 +3492,7 @@ def svdb_merge_panel_version(task) {
 process postprocess_merged_panel_sv_vcf {
 	cpus 2
 	tag "$group"
-	publishDir "${params.results_output_dir}/sv_vcf/merged/", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/merged/", mode: 'copy', overwrite: true, pattern: '*.vcf'
 	time '1h'
 	memory '1 GB'
 
@@ -3544,7 +3544,7 @@ def postprocess_merged_panel_sv_version(task) {
 
 process tiddit {
 	cpus  2
-	publishDir "${params.results_output_dir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/", mode: 'copy', overwrite: true, pattern: '*.vcf'
 	time '10h'
 	tag "$id"
 	memory '15 GB'
@@ -3586,7 +3586,7 @@ process svdb_merge {
 	cpus 2
 	container  "${params.container_svdb}"
 	tag "$group"
-	publishDir "${params.results_output_dir}/sv_vcf/merged/", mode: 'copy', overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/sv_vcf/merged/", mode: 'copy', overwrite: true, pattern: '*.vcf'
 	time '2h'
 	memory '1 GB'
 
@@ -3783,7 +3783,7 @@ process annotsv {
 	container  "${params.container_annotsv}"
 	cpus 2
 	tag "$group"
-	publishDir "${params.results_output_dir}/annotsv/", mode: 'copy', overwrite: true, pattern: '*.tsv'
+	publishDir "${params.outdir}/${params.subdir}/annotsv/", mode: 'copy', overwrite: true, pattern: '*.tsv'
 	time '5h'
 	memory '20 GB'
 
@@ -4223,8 +4223,8 @@ process bgzip_scored_genmod {
 	cpus 4
 	memory '1 GB'
 	time '5m'
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz.tbi'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz.tbi'
 	container  "${params.container_bcftools}"
 
 	input:
@@ -4269,7 +4269,7 @@ def bgzip_score_sv_version(task) {
 process compound_finder {
 	cpus 2
 	tag "$group ${params.mode}"
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz*'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz*'
 	memory '10 GB'
 	time '2h'
 
@@ -4348,7 +4348,7 @@ process output_files {
 
 
 process svvcf_to_bed {
-	publishDir "${params.results_output_dir}/bed", mode: 'copy' , overwrite: true
+	publishDir "${params.outdir}/${params.subdir}/bed", mode: 'copy' , overwrite: true
 	tag "group"
 	memory '1 GB'
 	time '1h'
@@ -4377,7 +4377,7 @@ process svvcf_to_bed {
 
 process plot_pod {
 	container  "${params.container_pod}"
-	publishDir "${params.results_output_dir}/pod", mode: 'copy' , overwrite: true
+	publishDir "${params.outdir}/${params.subdir}/pod", mode: 'copy' , overwrite: true
 	tag "$group"
 	time '1h'
 	memory '1 GB'
@@ -4403,8 +4403,8 @@ process plot_pod {
 }
 
 process create_yaml {
-	publishDir "${params.results_output_dir}/yaml", mode: 'copy' , overwrite: true, pattern: '*.yaml'
-	publishDir "${params.results_output_dir}/yaml/alt_affect", mode: 'copy' , overwrite: true, pattern: '*.yaml.*a'
+	publishDir "${params.outdir}/${params.subdir}/yaml", mode: 'copy' , overwrite: true, pattern: '*.yaml'
+	publishDir "${params.outdir}/${params.subdir}/yaml/alt_affect", mode: 'copy' , overwrite: true, pattern: '*.yaml.*a'
 	publishDir "${params.crondir}/scout", mode: 'copy' , overwrite: true, pattern: '*.yaml'
 	errorStrategy 'retry'
 	maxErrors 5
@@ -4441,7 +4441,7 @@ process create_yaml {
 }
 
 process combine_versions {
-	publishDir "${params.results_output_dir}/versions", mode: 'copy', overwrite: true, pattern: '*.versions.yml'
+	publishDir "${params.outdir}/${params.subdir}/versions", mode: 'copy', overwrite: true, pattern: '*.versions.yml'
 
 	input:
 		val(group)

--- a/workflows/annotate_snvs.nf
+++ b/workflows/annotate_snvs.nf
@@ -540,7 +540,7 @@ def genmodscore_version(task) {
 // Bgzipping and indexing VCF:
 process vcf_completion {
 	cpus 16
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz*'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz*'
 	tag "$group"
 	time '1h'
 	memory '5 GB'

--- a/workflows/annotate_snvs.nf
+++ b/workflows/annotate_snvs.nf
@@ -12,8 +12,6 @@ workflow SNV_ANNOTATE {
 
 	main:
 
-	// TODO: Better system so these two do not have to be redefined here.
-	params.results_output_dir = params.outdir + '/' + params.subdir
 	params.mode = file(params.csv).countLines() > 2 ? "family" : "single"
 
 	ch_versions = channel.empty()

--- a/workflows/melt.nf
+++ b/workflows/melt.nf
@@ -11,10 +11,7 @@ workflow MELT {
     vcf_header       // value: path(vcf_header)
     bed_intersect    // value: path(bed_intersect)
 
-    main:
-    // TODO: Do not redefine param here:
-	params.results_output_dir = params.outdir + '/' + params.subdir
-    
+    main:    
     ch_versions = channel.empty()
 
     ch_melt_in = ch_bam_bai

--- a/workflows/melt.nf
+++ b/workflows/melt.nf
@@ -94,7 +94,7 @@ process merge_melt {
 	tag "$id"
 	memory '2 GB'
 	time '1h'
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf'
 
 	input:
 		tuple val(group), val(id), path(alu_vcf), path(line1_vcf), path(sva_vcf)
@@ -125,7 +125,7 @@ process intersect_melt {
 	tag "$id"
 	memory '2 GB'
 	time '1h'
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy' , overwrite: true, pattern: '*.vcf'
     container "${params.container_bedtools}"
 
 	input:

--- a/workflows/split_normalize_snvs.nf
+++ b/workflows/split_normalize_snvs.nf
@@ -6,8 +6,6 @@ workflow SPLIT_NORMALIZE_SNVS {
 
     main:
     ch_versions = channel.empty()
-
-	params.results_output_dir = params.outdir + '/' + params.subdir
     
     vcflib_vcfbreakmulti(ch_family_snv_vcf_idx)
     bcftools_norm_sort(vcflib_vcfbreakmulti.out.vcf_tbi)

--- a/workflows/split_normalize_snvs.nf
+++ b/workflows/split_normalize_snvs.nf
@@ -71,7 +71,7 @@ process bcftools_norm_sort {
 	memory '10 GB'
 	time '1h'
     container "${params.container_bcftools}"
-    publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+    publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
     
     input:
 		tuple val(group), path(vcf), path(idx)
@@ -144,7 +144,7 @@ def vcflib_vcfuniq_version(task) {
 
 process wgs_dpaf_filter {
     cpus 2
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
 	tag "$group"
 	memory '10 GB'
 	time '1h'
@@ -221,7 +221,7 @@ def bedtool_intersect_version(task) {
 }
 process bgzip_tabix {
 	cpus 2
-    publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
+    publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
 	tag "$group"
 	memory '10 GB'
 	time '1h'

--- a/workflows/util.nf
+++ b/workflows/util.nf
@@ -34,7 +34,7 @@ def vcfHasVariants(Path vcf) {
 
 process bgzip_index_vcf {
 	cpus 16
-	publishDir "${params.results_output_dir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz*'
+	publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz*'
 	tag "$group"
 	time '1h'
 	memory '5 GB'


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Another LSP-error killer.

This removes the `params.results_output_dir` redefinition inside subworkflows/named workflows, which was an ugly workaround left over from the DSL2 migration.

Publishdir is now set the old way of using outdir/subdir.

In next step the process publishDir specifications will be removed altogether in favor of module configs, and finally switched to workflow outputs when we've upgraded to nextflow 25.10


## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [ ] Self-review of my code
- [ ] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Documentation
- [ ] At least one other person has reviewed my changes (not required for trivial changes)

## Patch
- [x] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

## Major / Minor change

- [x] GIAB single (wgs) stub run finishes and differences to current master branch have been investigated (using [PipeEval](https://github.com/Clinical-Genomics-Lund/PipeEval))
- [x] GIAB trio (wgs) stub run finishes and differences to current master branch have been investigated
- [x] Seracare (onco) stub run sample finishes and differences to current master branch have been investigated
- [ ] Output from processes with altered code have been inspected (i.e. in the work folder: .command.sh, .command.log, .command.err and result files)
- [ ] If relevant for your changes - All three samples can be loaded into Scout
- [ ] At least one other person has reviewed and approved my code
- [ ] I have made corresponding changes to the documentation (software versions, etc.)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
